### PR TITLE
feat(@repo/intershell): add --bump-type option to version-prepare script

### DIFF
--- a/docs/7_AUTO_VERSIONING.md
+++ b/docs/7_AUTO_VERSIONING.md
@@ -34,6 +34,8 @@ The Monobun monorepo uses a modern, automated versioning system that provides so
 ```bash
 # Prepare version and changelog
 bun run scripts/version-prepare.ts --package root
+# Override version bump type manually
+bun run scripts/version-prepare.ts --package root --bump-type major
 # Use version ranges for targeted changelog generation
 bun run scripts/version-prepare.ts --from-version 1.0.0 --to-version 1.2.0
 # Apply changes without pushing
@@ -250,6 +252,33 @@ git commit -m "release(api): api-v1.2.0 [minor]
 # No version bump
 git commit -m "docs: update API documentation"
 ```
+
+## 🎯 Manual Version Override
+
+Sometimes you need to override the automatic version bump calculation. Use the `--bump-type` option to manually specify the version bump type:
+
+### **Override Examples**
+
+```bash
+# Force a major version bump
+bun run scripts/version-prepare.ts --package root --bump-type major
+
+# Force a minor version bump  
+bun run scripts/version-prepare.ts --package api --bump-type minor
+
+# Force a patch version bump
+bun run scripts/version-prepare.ts --package ui --bump-type patch
+
+# Prevent any version bump
+bun run scripts/version-prepare.ts --package utils --bump-type none
+```
+
+### **When to Use Override**
+
+- **Major**: When you want to signal a breaking change regardless of commit messages
+- **Minor**: When you want to add new features without breaking changes
+- **Patch**: When you want to make bug fixes or small improvements
+- **None**: When you want to generate changelog without version changes
 
 ## 🚀 GitHub Actions Integration
 

--- a/docs/planning/27_REMAINING_WORK_SUMMARY.md
+++ b/docs/planning/27_REMAINING_WORK_SUMMARY.md
@@ -55,9 +55,9 @@ This document summarizes all completed work from the dependency analyzer, select
 
 ### **Phase 1: Advanced Features (Future)**
 
-#### **1.1 Semantic Versioning Enhancements**
-- **Predefined Version Tags**: Create a temp file to set pre-defined version bump type for each package
-- **Prerelease Support**: Alpha, beta, RC versions within each series
+#### **1.1 Semantic Versioning Enhancements** - ✅ COMPLETED
+- **Override Version Bump Types**: Added `--bump-type` option to `version-prepare` script for manual version control
+- **Prerelease Support**: Alpha, beta, RC versions within each series (Future)
 
 #### **1.2 Move Scripts to Intershell**
 - **Multi Command Feature**: A multi command feature for wrapshell - huge change!

--- a/packages/intershell/src/entities/package-version/package-version.test.ts
+++ b/packages/intershell/src/entities/package-version/package-version.test.ts
@@ -114,4 +114,28 @@ describe("EntityPackageVersion", () => {
 		const versionData = await EntityPackageVersion.calculateVersionData(commits);
 		expect(versionData.bumpType).toBe("minor");
 	});
+
+	test("should use override bump type when provided", async () => {
+		const EntityPackageVersion = createEntityPackageVersion("api");
+
+		const commits: ParsedCommitData[] = [
+			{
+				message: { type: "feat", description: "add new feature", isBreaking: false },
+				files: ["src/feature.ts"],
+			} as ParsedCommitData,
+		];
+
+		// Test with major override (should override the automatic minor bump)
+		const versionDataMajor = await EntityPackageVersion.calculateVersionData(commits, "major");
+		expect(versionDataMajor.bumpType).toBe("major");
+
+		// Test with patch override (should override the automatic minor bump)
+		const versionDataPatch = await EntityPackageVersion.calculateVersionData(commits, "patch");
+		expect(versionDataPatch.bumpType).toBe("patch");
+
+		// Test with none override (should prevent version bump)
+		const versionDataNone = await EntityPackageVersion.calculateVersionData(commits, "none");
+		expect(versionDataNone.bumpType).toBe("none");
+		expect(versionDataNone.shouldBump).toBe(false);
+	});
 });

--- a/packages/intershell/src/entities/package-version/package-version.ts
+++ b/packages/intershell/src/entities/package-version/package-version.ts
@@ -22,7 +22,10 @@ export class EntityPackageVersion {
 		this.packageTags = packageTags;
 	}
 
-	async calculateVersionData(commits: ParsedCommitData[]): Promise<EntityPackageVersionData> {
+	async calculateVersionData(
+		commits: ParsedCommitData[],
+		overrideBumpType?: EntityPackageVersionBumpType,
+	): Promise<EntityPackageVersionData> {
 		const versionOnDisk = this.package.readVersion() || "0.0.0";
 		const currentVersion = (await this.packageTags.getLatestPackageVersionInHistory()) || "0.0.0";
 
@@ -60,7 +63,7 @@ export class EntityPackageVersion {
 			};
 		}
 
-		const bumpType = await this.calculateBumpType(commits);
+		const bumpType = overrideBumpType || (await this.calculateBumpType(commits));
 		if (bumpType === "none") {
 			return {
 				currentVersion,


### PR DESCRIPTION
#### 📊 Summary
Add manual version bump override functionality to the version-prepare script for fine-grained control over versioning.

- Add --bump-type CLI option with validation for major, minor, patch, and none
- Update EntityPackageVersion to accept optional overrideBumpType parameter
- Add comprehensive tests for override functionality
- Update documentation with usage examples and guidelines
- Mark semantic versioning enhancements as completed

This provides developers with precise control over version bumping when automatic conventional commit analysis doesn't match their needs.