### PR TITLE
Use @types/bun instead of direct bun-types

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -17,6 +17,7 @@
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "workspace:*",
+		"@types/bun": "1.3.14",
 		"@types/react": "19.1.17",
 		"@types/react-dom": "19.1.11",
 		"@vitejs/plugin-react": "5.0.4",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
 	"devDependencies": {
 		"@repo/test-preset": "workspace:*",
 		"@repo/typescript-config": "workspace:*",
+		"@types/bun": "1.3.14",
 		"@types/body-parser": "1.19.6",
 		"@types/cors": "2.8.19",
 		"@types/express": "5.0.6",

--- a/apps/docs-astro/astro.config.ts
+++ b/apps/docs-astro/astro.config.ts
@@ -1,11 +1,11 @@
 import tailwindcss from "@tailwindcss/vite";
-import { type AstroUserConfig, defineConfig } from "astro/config";
+import { defineConfig } from "astro/config";
 
 const port = process.env.PORT ? Number(process.env.PORT) : 4321;
 const host = process.env.HOST || "localhost";
 const site = process.env.NODE_ENV === "development" ? `http://${host}:${port}` : `http://${host}`;
 
-const config: AstroUserConfig = defineConfig({
+export default defineConfig({
 	output: "static",
 	site,
 	base: "",
@@ -13,5 +13,3 @@ const config: AstroUserConfig = defineConfig({
 		plugins: [tailwindcss()],
 	},
 });
-
-export default config;

--- a/apps/docs-astro/package.json
+++ b/apps/docs-astro/package.json
@@ -21,6 +21,7 @@
 	"devDependencies": {
 		"@astrojs/check": "0.9.9",
 		"@repo/typescript-config": "workspace:*",
+		"@types/bun": "1.3.14",
 		"@tailwindcss/vite": "4.1.15",
 		"tailwindcss": "4.1.15",
 		"typescript": "5.9.3"

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -18,6 +18,7 @@
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "workspace:*",
+		"@types/bun": "1.3.14",
 		"@types/node": "20.19.11",
 		"@types/react": "19.1.17",
 		"@types/react-dom": "19.1.11"

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
+        "@types/bun": "1.3.14",
         "@types/react": "19.1.17",
         "@types/react-dom": "19.1.11",
         "@vitejs/plugin-react": "5.0.4",
@@ -47,6 +48,7 @@
         "@repo/test-preset": "workspace:*",
         "@repo/typescript-config": "workspace:*",
         "@types/body-parser": "1.19.6",
+        "@types/bun": "1.3.14",
         "@types/cors": "2.8.19",
         "@types/express": "5.0.6",
         "@types/morgan": "1.9.10",
@@ -68,6 +70,7 @@
         "@astrojs/check": "0.9.9",
         "@repo/typescript-config": "workspace:*",
         "@tailwindcss/vite": "4.1.15",
+        "@types/bun": "1.3.14",
         "tailwindcss": "4.1.15",
         "typescript": "5.9.3",
       },
@@ -83,6 +86,7 @@
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
+        "@types/bun": "1.3.14",
         "@types/node": "20.19.11",
         "@types/react": "19.1.17",
         "@types/react-dom": "19.1.11",
@@ -96,12 +100,13 @@
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.6.4",
         "@testing-library/react": "16.3.2",
+        "@types/bun": "1.3.14",
       },
     },
     "packages/typescript-config": {
       "name": "@repo/typescript-config",
       "peerDependencies": {
-        "bun-types": "1.3.1",
+        "@types/bun": "1.3.14",
         "typescript": "5.9.3",
       },
     },
@@ -129,6 +134,7 @@
         "@storybook/react": "9.0.18",
         "@storybook/react-vite": "9.0.18",
         "@storybook/testing-library": "0.2.2",
+        "@types/bun": "1.3.14",
         "autoprefixer": "10.4.21",
         "serve": "14.2.5",
         "storybook": "9.1.19",
@@ -144,8 +150,8 @@
       },
       "devDependencies": {
         "@repo/typescript-config": "workspace:*",
+        "@types/bun": "1.3.14",
         "@types/node": "20.19.11",
-        "bun-types": "1.3.1",
       },
     },
   },
@@ -736,7 +742,7 @@
 
     "browserslist": ["browserslist@4.25.3", "", { "dependencies": { "caniuse-lite": "^1.0.30001735", "electron-to-chromium": "^1.5.204", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ=="],
 
-    "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -2055,8 +2061,6 @@
     "@types/babel__core/@babel/parser": ["@babel/parser@7.28.3", "", { "dependencies": { "@babel/types": "^7.28.2" }, "bin": "./bin/babel-parser.js" }, "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA=="],
 
     "@types/babel__template/@babel/parser": ["@babel/parser@7.28.3", "", { "dependencies": { "@babel/types": "^7.28.2" }, "bin": "./bin/babel-parser.js" }, "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA=="],
-
-    "@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@vitest/mocker/magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
 

--- a/packages/test-preset/package.json
+++ b/packages/test-preset/package.json
@@ -13,9 +13,10 @@
 	},
 	"devDependencies": {
 		"@happy-dom/global-registrator": "18.0.1",
-		"@testing-library/jest-dom": "6.6.4",
+		"@repo/typescript-config": "workspace:*",
 		"@testing-library/dom": "10.4.1",
+		"@testing-library/jest-dom": "6.6.4",
 		"@testing-library/react": "16.3.2",
-		"@repo/typescript-config": "workspace:*"
+		"@types/bun": "1.3.14"
 	}
 }

--- a/packages/test-preset/tsconfig.json
+++ b/packages/test-preset/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"noEmit": false,
-		"types": ["node", "bun-types"]
+		"types": ["node", "bun"]
 	},
 	"include": ["."]
 }

--- a/packages/typescript-config/AGENTS.md
+++ b/packages/typescript-config/AGENTS.md
@@ -188,8 +188,8 @@ Be explicit about what TypeScript should process:
 ## Dependencies
 
 ### Peer Dependencies
-- **typescript** `5.8.3` - TypeScript compiler
-- **bun-types** `1.3.1` - Bun runtime types
+- **typescript** `5.9.3` - TypeScript compiler
+- **@types/bun** `1.3.14` - Bun runtime types (via DefinitelyTyped wrapper)
 
 These are peer dependencies to avoid version conflicts and allow projects to control their TypeScript version.
 

--- a/packages/typescript-config/TSCONFIG.md
+++ b/packages/typescript-config/TSCONFIG.md
@@ -132,7 +132,7 @@ Specify type package names to include without glob patterns.
 ```json
 {
   "compilerOptions": {
-    "types": ["node", "bun-types"]
+    "types": ["node", "bun"]
   }
 }
 ```

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -4,7 +4,7 @@
 		"module": "ESNext",
 		"moduleResolution": "Bundler",
 		"target": "ESNext",
-		"types": ["node", "bun-types"],
+		"types": ["node", "bun"],
 		"composite": false,
 		"declaration": true,
 		"declarationMap": true,

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -9,6 +9,6 @@
 	},
 	"peerDependencies": {
 		"typescript": "5.9.3",
-		"bun-types": "1.3.1"
+		"@types/bun": "1.3.14"
 	}
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,6 +41,7 @@
 	"devDependencies": {
 		"@repo/test-preset": "workspace:*",
 		"@repo/typescript-config": "workspace:*",
+		"@types/bun": "1.3.14",
 		"@storybook/addon-a11y": "9.0.18",
 		"@storybook/addon-links": "9.0.18",
 		"@storybook/addon-themes": "9.0.18",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,7 @@
 	},
 	"devDependencies": {
 		"@repo/typescript-config": "workspace:*",
-		"@types/node": "20.19.11",
-		"bun-types": "1.3.1"
+		"@types/bun": "1.3.14",
+		"@types/node": "20.19.11"
 	}
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,6 @@
 		"@repo/typescript-config": "workspace:*",
 		"@types/bun": "1.3.14",
 		"@types/react": "19.2.2",
-		"bun-types": "1.3.1",
 		"typescript": "5.9.3"
 	}
 }


### PR DESCRIPTION
## Summary

Standardize Bun TypeScript typings on the `@types/bun` package (DefinitelyTyped wrapper) instead of declaring `bun-types` directly, and align `compilerOptions.types` with the `@types/bun` entry name (`bun`). Includes a small docs-astro config fix so `astro check` matches Astro 6 exports.

## What has changed?

- Shared `base.json` and `@repo/test-preset` tsconfig now use `"types": ["node", "bun"]` instead of `bun-types`.
- `@repo/typescript-config` peer dependency is `@types/bun` at `1.3.14` (replacing `bun-types`).
- Removed direct `bun-types` from `scripts` and `@repo/utils`; added `@types/bun` to apps and packages that rely on shared TS config.
- `apps/docs-astro/astro.config.ts`: import only `defineConfig` from `astro/config` (Astro 6 no longer re-exports `AstroUserConfig` from that entry).
- Lockfile updated; `@repo/test-preset` keeps upstream `@testing-library/react` `16.3.2` and adds `@types/bun`.

## How to test it?

- [x] `bun overall`

Made with [Cursor](https://cursor.com)