### PR TITLE
feat(root): add nuke reset and improve dev tooling CLIs

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,5 +13,5 @@ RUN --mount=type=cache,target=/root/.bun/install/cache \
 RUN --mount=type=cache,target=/app/.turbo \
     mkdir -p .turbo/cache && \
     chmod -R 777 .turbo
-    
-CMD ["sleep", "infinity"] 
+
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -150,13 +150,8 @@ curl -fsSL https://bun.com/install | bash
 # Clone and go! 🏃‍♂️
 git clone https://github.com/movahedan/monobun.git && cd monobun
 
-bun install
-bun run local setup
-bun run container setup && bun run container up && bun run container check
-bun run overall
-
-# Reset dev stack + local artifacts when things get weird:
-bun run container cleanup && bun run local cleanup
+bun nuke
+bun overall
 ```
 
 [![Star](https://img.shields.io/badge/⭐%20Star%20This%20Repo-Support%20Us-00D4AA?style=for-the-badge)](https://github.com/movahedan/monobun)

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -16,9 +16,8 @@ RUN turbo prune --scope=admin --docker
 FROM turbo AS installer
 WORKDIR /app
 COPY --from=pruner /app/out/json/ .
-COPY bun.lock ./bun.lock
-COPY --from=pruner /app/out/full/ .
-RUN bun install --ignore-scripts
+RUN --mount=type=cache,target=/root/.bun/install/cache,id=monobun-bun-cache-admin \
+	bun install --ignore-scripts
 
 FROM turbo AS build
 WORKDIR /app

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -16,9 +16,8 @@ RUN turbo prune --scope=api --docker
 FROM turbo AS installer
 WORKDIR /app
 COPY --from=pruner /app/out/json/ .
-COPY bun.lock ./bun.lock
-COPY --from=pruner /app/out/full/ .
-RUN bun install --ignore-scripts
+RUN --mount=type=cache,target=/root/.bun/install/cache,id=monobun-bun-cache-api \
+	bun install --ignore-scripts
 
 FROM turbo AS build
 WORKDIR /app

--- a/apps/docs-astro/Dockerfile
+++ b/apps/docs-astro/Dockerfile
@@ -16,9 +16,8 @@ RUN bunx turbo prune --scope=docs-astro --docker
 FROM turbo AS installer
 WORKDIR /app
 COPY --from=pruner /app/out/json/ .
-COPY bun.lock ./bun.lock
-COPY --from=pruner /app/out/full/ .
-RUN bun install --ignore-scripts
+RUN --mount=type=cache,target=/root/.bun/install/cache,id=monobun-bun-cache-docs-astro \
+	bun install --ignore-scripts
 
 FROM turbo AS build
 WORKDIR /app

--- a/apps/storefront/Dockerfile
+++ b/apps/storefront/Dockerfile
@@ -16,9 +16,8 @@ RUN turbo prune --scope=storefront --docker
 FROM turbo AS installer
 WORKDIR /app
 COPY --from=pruner /app/out/json/ .
-COPY bun.lock ./bun.lock
-COPY --from=pruner /app/out/full/ .
-RUN bun install --ignore-scripts
+RUN --mount=type=cache,target=/root/.bun/install/cache,id=monobun-bun-cache-storefront \
+	bun install --ignore-scripts
 
 FROM turbo AS build
 WORKDIR /app

--- a/apps/storefront/next-env.d.ts
+++ b/apps/storefront/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@types/bun": "1.3.14",
         "@types/react": "19.2.14",
         "ink": "7.0.3",
-        "intershell": "0.6.1",
+        "intershell": "0.6.2",
         "lefthook": "2.1.6",
         "react": "19.2.6",
         "safe-regex": "2.1.1",
@@ -1221,7 +1221,7 @@
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
-    "intershell": ["intershell@0.6.1", "", { "peerDependencies": { "turbo": "2.5.8" } }, "sha512-lHyEbYuaxla95RB6yITvYTqV0IwF+U0IK4SFeuYDR3pJykZDfVS9Kk87iVvcYc+KgrU2Mde/0U4IHNTxdf3jgg=="],
+    "intershell": ["intershell@0.6.2", "", { "peerDependencies": { "turbo": "2.5.8" } }, "sha512-pILSzmIsmJxYUV/H41kmYUakRZMO6LkoHajZabmPH+u/CQTQwqosvfkF6lf1nlFaLHSoWdadWwuEWzeRXMu43A=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,7 @@ services:
       - ${PROJECT_ROOT:-./}/package.json:/app/package.json:cached
       - ${PROJECT_ROOT:-./}/bun.lock:/app/bun.lock:cached
       - ${PROJECT_ROOT:-./}/turbo.json:/app/turbo.json:cached
+      - ${PROJECT_ROOT:-./}/intershell.config.ts:/app/intershell.config.ts:cached
       # Override volumes
       - node_modules:/app/node_modules:delegated
       - turbo_cache:/app/.turbo:delegated

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"@types/bun": "1.3.14",
 		"@types/react": "19.2.14",
 		"ink": "7.0.3",
-		"intershell": "0.6.1",
+		"intershell": "0.6.2",
 		"lefthook": "2.1.6",
 		"react": "19.2.6",
 		"safe-regex": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	},
 	"scripts": {
 		"postinstall": "lefthook install",
+		"nuke": "bun scripts/nuke/index.tsx",
 		"local": "bun scripts/local/index.tsx",
 		"turbo": "turbo",
 		"lint": "biome check .",

--- a/packages/ui/Dockerfile
+++ b/packages/ui/Dockerfile
@@ -16,8 +16,8 @@ RUN turbo prune --scope=@repo/ui --docker
 FROM turbo AS installer
 WORKDIR /app
 COPY --from=pruner /app/out/json/ .
-COPY bun.lock ./bun.lock
-RUN bun install --ignore-scripts
+RUN --mount=type=cache,target=/root/.bun/install/cache,id=monobun-bun-cache-ui \
+	bun install --ignore-scripts
 
 FROM turbo AS build
 WORKDIR /app

--- a/scripts/compose-plain-progress.ts
+++ b/scripts/compose-plain-progress.ts
@@ -1,0 +1,29 @@
+export const INK_PROGRESS_ENV = "MONOBUN_INK_PROGRESS";
+
+export function isInkProgressActive(): boolean {
+	return process.env[INK_PROGRESS_ENV] === "1";
+}
+
+export function getPlainComposeSpawnEnv(base: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	if (!isInkProgressActive()) {
+		return base;
+	}
+	return {
+		...base,
+		COMPOSE_ANSI: "never",
+		BUILDKIT_PROGRESS: "plain",
+	};
+}
+
+export function applyPlainComposeArgv(argv: readonly string[]): string[] {
+	if (!isInkProgressActive() || argv.includes("--progress")) {
+		return [...argv];
+	}
+	const composeIndex = argv.indexOf("compose");
+	if (composeIndex === -1) {
+		return [...argv];
+	}
+	const result = [...argv];
+	result.splice(composeIndex + 1, 0, "--progress", "plain");
+	return result;
+}

--- a/scripts/container/check.tsx
+++ b/scripts/container/check.tsx
@@ -1,10 +1,9 @@
 import { setTimeout } from "node:timers/promises";
 import { parseArgs } from "node:util";
 import { EntityCompose, type ServiceHealth, type ServiceInfo } from "intershell";
-import { type ReactNode, useCallback } from "react";
 import { colorify } from "../colorify";
-import { renderAndExit } from "../render-and-exit";
-import { StepProgressApp, type StepProgressStep } from "../step-progress";
+import { runStepsInTerminal } from "../run-terminal-steps";
+import type { StepProgressStep } from "../step-progress";
 import { getComposeFilePath, spawnContainerIndex } from "./stack";
 
 const HEALTH_ICONS: Record<ServiceHealth["status"], string> = {
@@ -142,16 +141,6 @@ async function runCheckSteps(options: CheckOptions): Promise<void> {
 	for (const step of getCheckSteps(options)) await step.run();
 }
 
-function CheckApp({ options }: { readonly options: CheckOptions }): ReactNode {
-	const resolveSteps = useCallback(() => getCheckSteps(options), [options]);
-	return (
-		<StepProgressApp
-			completedHeading="Compose stack health check completed"
-			resolveSteps={resolveSteps}
-		/>
-	);
-}
-
 export async function runCheck(rest: readonly string[]): Promise<void> {
 	const { values } = parseArgs({
 		args: [...rest],
@@ -170,7 +159,7 @@ export async function runCheck(rest: readonly string[]): Promise<void> {
 	if (options.quiet) {
 		await runCheckSteps(options);
 	} else {
-		await renderAndExit(<CheckApp options={options} />);
+		await runStepsInTerminal(getCheckSteps(options), { heading: "Compose stack health check" });
 	}
 
 	console.log(colorify.green("✅ Compose stack health check completed successfully!"));

--- a/scripts/container/cleanup.tsx
+++ b/scripts/container/cleanup.tsx
@@ -1,6 +1,7 @@
 import { parseArgs } from "node:util";
 import { type ReactNode, useCallback } from "react";
 import { colorify } from "../colorify";
+import { applyPlainComposeArgv } from "../compose-plain-progress";
 import { renderAndExit } from "../render-and-exit";
 import { StepProgressApp, type StepProgressStep } from "../step-progress";
 import { getComposePrefix, getComposeSpawnEnv } from "./stack";
@@ -11,13 +12,14 @@ export interface CleanupOptions {
 }
 
 async function spawnCompose(args: readonly string[], verbose: boolean): Promise<number> {
+	const argv = applyPlainComposeArgv(args);
 	const proc = verbose
-		? Bun.spawn([...args], {
+		? Bun.spawn(argv, {
 				stdio: ["inherit", "inherit", "inherit"],
 				cwd: process.cwd(),
 				env: getComposeSpawnEnv(),
 			})
-		: Bun.spawn([...args], {
+		: Bun.spawn(argv, {
 				stdio: ["ignore", "pipe", "pipe"],
 				cwd: process.cwd(),
 				env: getComposeSpawnEnv(),
@@ -80,7 +82,9 @@ export async function runCleanup(rest: readonly string[]): Promise<void> {
 		await renderAndExit(<CleanupApp options={options} />);
 	}
 
-	console.log(colorify.cyan("\nTo start the stack again:"));
-	console.log(colorify.cyan("  - bun run container setup"));
-	console.log(colorify.cyan("  - bun run container rm  (host only — full compose teardown)"));
+	if (!options.quiet) {
+		console.log(colorify.cyan("\nTo start the stack again:"));
+		console.log(colorify.cyan("  - bun run container setup"));
+		console.log(colorify.cyan("  - bun run container rm  (host only — full compose teardown)"));
+	}
 }

--- a/scripts/container/index.tsx
+++ b/scripts/container/index.tsx
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { applyPlainComposeArgv } from "../compose-plain-progress";
 import { printCliErrorAndExit } from "../format-cli-error";
 import { runCheck } from "./check";
 import { runCleanup } from "./cleanup";
@@ -49,7 +50,7 @@ function parseGlobalFlags(argv: readonly string[]): {
 }
 
 async function spawnComposeExit(argv: readonly string[]): Promise<never> {
-	const proc = Bun.spawn([...argv], {
+	const proc = Bun.spawn(applyPlainComposeArgv(argv), {
 		stdio: ["inherit", "inherit", "inherit"],
 		cwd: process.cwd(),
 		env: getComposeSpawnEnv(),
@@ -99,7 +100,7 @@ async function main(): Promise<void> {
 	}
 
 	if (sub === "up") {
-		await spawnComposeExit([...getComposePrefix(), "up", "-d", ...subRest]);
+		await spawnComposeExit(applyPlainComposeArgv([...getComposePrefix(), "up", "-d", ...subRest]));
 	}
 
 	if (sub === "down") {
@@ -111,7 +112,7 @@ async function main(): Promise<void> {
 	}
 
 	if (sub === "build") {
-		await spawnComposeExit([...getComposePrefix(), "build", ...subRest]);
+		await spawnComposeExit(applyPlainComposeArgv([...getComposePrefix(), "build", ...subRest]));
 	}
 
 	await runRm(subRest);

--- a/scripts/container/rm.tsx
+++ b/scripts/container/rm.tsx
@@ -1,6 +1,7 @@
 import { parseArgs } from "node:util";
 import { type ReactNode, useCallback } from "react";
 import { colorify } from "../colorify";
+import { applyPlainComposeArgv, getPlainComposeSpawnEnv } from "../compose-plain-progress";
 import { renderAndExit } from "../render-and-exit";
 import { StepProgressApp, type StepProgressStep } from "../step-progress";
 import { DEV_COMPOSE_FILE, PROD_COMPOSE_FILE, PROD_COMPOSE_PROJECT_NAME } from "./stack";
@@ -10,16 +11,18 @@ async function spawnDocker(
 	env: NodeJS.ProcessEnv,
 	verbose: boolean,
 ): Promise<number> {
+	const argv = applyPlainComposeArgv(args);
+	const spawnEnv = getPlainComposeSpawnEnv(env);
 	const proc = verbose
-		? Bun.spawn([...args], {
+		? Bun.spawn(argv, {
 				stdio: ["inherit", "inherit", "inherit"],
 				cwd: process.cwd(),
-				env,
+				env: spawnEnv,
 			})
-		: Bun.spawn([...args], {
+		: Bun.spawn(argv, {
 				stdio: ["ignore", "pipe", "pipe"],
 				cwd: process.cwd(),
-				env,
+				env: spawnEnv,
 			});
 	return await proc.exited;
 }

--- a/scripts/container/setup.tsx
+++ b/scripts/container/setup.tsx
@@ -1,8 +1,7 @@
 import { parseArgs } from "node:util";
-import { type ReactNode, useCallback } from "react";
 import { colorify } from "../colorify";
-import { renderAndExit } from "../render-and-exit";
-import { StepProgressApp, type StepProgressStep } from "../step-progress";
+import { runStepsInTerminal } from "../run-terminal-steps";
+import type { StepProgressStep } from "../step-progress";
 import { spawnContainerIndex } from "./stack";
 
 export interface SetupOptions {
@@ -36,13 +35,6 @@ async function runSetupSteps(options: SetupOptions): Promise<void> {
 	for (const step of getSetupSteps(options)) await step.run();
 }
 
-function SetupApp({ options }: { readonly options: SetupOptions }): ReactNode {
-	const resolveSteps = useCallback(() => getSetupSteps(options), [options]);
-	return (
-		<StepProgressApp completedHeading="Compose stack setup completed" resolveSteps={resolveSteps} />
-	);
-}
-
 async function printServiceHints(): Promise<void> {
 	console.log(colorify.yellow("Run bun run container cleanup to stop services when done"));
 	console.log(colorify.cyan("\nUseful commands:"));
@@ -69,7 +61,7 @@ export async function runSetup(rest: readonly string[]): Promise<void> {
 	if (options.quiet) {
 		await runSetupSteps(options);
 	} else {
-		await renderAndExit(<SetupApp options={options} />);
+		await runStepsInTerminal(getSetupSteps(options), { heading: "Compose stack setup" });
 	}
 
 	await printServiceHints();

--- a/scripts/container/stack.ts
+++ b/scripts/container/stack.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 
+import { getPlainComposeSpawnEnv } from "../compose-plain-progress";
+
 export type ContainerStack = "dev" | "prod";
 
 let currentStack: ContainerStack = "dev";
@@ -21,10 +23,11 @@ export function getComposeFilePath(): string {
 }
 
 export function getComposeSpawnEnv(): NodeJS.ProcessEnv {
-	if (getContainerStack() === "prod") {
-		return { ...process.env, COMPOSE_PROJECT_NAME: PROD_COMPOSE_PROJECT_NAME };
-	}
-	return { ...process.env };
+	const base =
+		getContainerStack() === "prod"
+			? { ...process.env, COMPOSE_PROJECT_NAME: PROD_COMPOSE_PROJECT_NAME }
+			: { ...process.env };
+	return getPlainComposeSpawnEnv(base);
 }
 
 export function getComposePrefix(): readonly string[] {
@@ -44,6 +47,7 @@ export async function spawnContainerIndex(subcommandArgs: readonly string[]): Pr
 	const proc = Bun.spawn(argvContainerIndex(subcommandArgs), {
 		stdio: ["inherit", "inherit", "inherit"],
 		cwd: process.cwd(),
+		env: getComposeSpawnEnv(),
 	});
 	return await proc.exited;
 }

--- a/scripts/local/cleanup.tsx
+++ b/scripts/local/cleanup.tsx
@@ -1,3 +1,4 @@
+import { parseArgs } from "node:util";
 import { $ } from "bun";
 import { type ReactNode, useCallback } from "react";
 
@@ -55,11 +56,28 @@ function getCleanupSteps(): readonly StepProgressStep[] {
 	];
 }
 
+export async function runLocalCleanupSteps(): Promise<void> {
+	for (const step of getCleanupSteps()) await step.run();
+}
+
 function CleanupApp(): ReactNode {
 	const resolveSteps = useCallback(() => getCleanupSteps(), []);
 	return <StepProgressApp completedHeading="Local cleanup completed" resolveSteps={resolveSteps} />;
 }
 
-export async function runLocalCleanup(): Promise<void> {
+export async function runLocalCleanup(rest: readonly string[]): Promise<void> {
+	const { values } = parseArgs({
+		args: [...rest],
+		options: {
+			quiet: { type: "boolean", default: false },
+		},
+		strict: true,
+	});
+
+	if (values.quiet === true) {
+		await runLocalCleanupSteps();
+		return;
+	}
+
 	await renderAndExit(<CleanupApp />);
 }

--- a/scripts/local/help.tsx
+++ b/scripts/local/help.tsx
@@ -22,9 +22,11 @@ function HelpApp({ errorMessage }: { readonly errorMessage?: string }) {
 			<Text>
 				<Text color="green">setup</Text> — install deps, check, test, build
 			</Text>
+			<Text dimColor> setup flags: --skip-tests, --quiet</Text>
 			<Text>
 				<Text color="green">cleanup</Text> — remove build artifacts and node_modules
 			</Text>
+			<Text dimColor> cleanup flags: --quiet</Text>
 			<Text>
 				<Text color="green">vscode</Text> — sync .vscode settings and extensions from the workspace
 			</Text>

--- a/scripts/local/index.tsx
+++ b/scripts/local/index.tsx
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
 	}
 
 	if (sub === "cleanup") {
-		await runLocalCleanup();
+		await runLocalCleanup(rest);
 		return;
 	}
 

--- a/scripts/local/setup.tsx
+++ b/scripts/local/setup.tsx
@@ -17,6 +17,10 @@ function getSetupSteps(skipTests: boolean): readonly StepProgressStep[] {
 	return steps;
 }
 
+export async function runLocalSetupSteps(skipTests: boolean): Promise<void> {
+	for (const step of getSetupSteps(skipTests)) await step.run();
+}
+
 function SetupApp({ skipTests }: { readonly skipTests: boolean }): ReactNode {
 	const resolveSteps = useCallback(() => getSetupSteps(skipTests), [skipTests]);
 	return <StepProgressApp completedHeading="Local setup completed" resolveSteps={resolveSteps} />;
@@ -27,9 +31,17 @@ export async function runLocalSetup(rest: readonly string[]): Promise<void> {
 		args: [...rest],
 		options: {
 			"skip-tests": { type: "boolean", short: "t", default: false },
+			quiet: { type: "boolean", default: false },
 		},
 		strict: true,
 	});
 
-	await renderAndExit(<SetupApp skipTests={values["skip-tests"] === true} />);
+	const skipTests = values["skip-tests"] === true;
+
+	if (values.quiet === true) {
+		await runLocalSetupSteps(skipTests);
+		return;
+	}
+
+	await renderAndExit(<SetupApp skipTests={skipTests} />);
 }

--- a/scripts/nuke/help.tsx
+++ b/scripts/nuke/help.tsx
@@ -1,0 +1,49 @@
+import { Box, render, Text, useApp } from "ink";
+import { useEffect } from "react";
+
+function HelpApp({ errorMessage }: { readonly errorMessage?: string }) {
+	const { exit, waitUntilRenderFlush } = useApp();
+
+	useEffect(() => {
+		void (async () => {
+			await waitUntilRenderFlush();
+			exit();
+		})();
+	}, [exit, waitUntilRenderFlush]);
+
+	return (
+		<Box flexDirection="column" padding={1}>
+			<Text bold color="cyan">
+				bun run nuke
+			</Text>
+			{errorMessage !== undefined ? <Text color="red">{errorMessage}</Text> : null}
+			<Text> </Text>
+			<Text dimColor>
+				Full factory reset: wipe local artifacts and both compose stacks, bootstrap the workspace,
+				then smoke-test dev and prod compose.
+			</Text>
+			<Text> </Text>
+			<Text bold>Flags</Text>
+			<Text>
+				<Text color="green">--quiet</Text> / <Text color="green">-q</Text> — run steps without Ink
+			</Text>
+			<Text>
+				<Text color="green">--skip-tests</Text> / <Text color="green">-t</Text> — skip tests during
+				local setup
+			</Text>
+			<Text> </Text>
+			<Text bold>Examples</Text>
+			<Text dimColor>bun run nuke</Text>
+			<Text dimColor>bun run nuke -- --skip-tests</Text>
+			<Text dimColor>bun run nuke -- --quiet</Text>
+		</Box>
+	);
+}
+
+export async function printNukeHelpAndExit(errorMessage?: string): Promise<never> {
+	const code = errorMessage === undefined ? 0 : 1;
+	const { waitUntilExit, unmount } = render(<HelpApp errorMessage={errorMessage} />);
+	await waitUntilExit();
+	unmount();
+	process.exit(code);
+}

--- a/scripts/nuke/index.tsx
+++ b/scripts/nuke/index.tsx
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+import { parseArgs } from "node:util";
+
+import { printCliErrorAndExit } from "../format-cli-error";
+import { printNukeHelpAndExit } from "./help";
+import { runNuke } from "./run";
+
+async function main(): Promise<void> {
+	const argv = Bun.argv.slice(2);
+
+	try {
+		const { values, positionals } = parseArgs({
+			args: [...argv],
+			options: {
+				quiet: { type: "boolean", short: "q", default: false },
+				"skip-tests": { type: "boolean", short: "t", default: false },
+				help: { type: "boolean", short: "h", default: false },
+			},
+			allowPositionals: true,
+			strict: true,
+		});
+
+		if (positionals.length > 0) {
+			await printNukeHelpAndExit(`Unexpected arguments: ${positionals.join(" ")}`);
+		}
+
+		if (values.help === true) {
+			await printNukeHelpAndExit();
+		}
+
+		await runNuke({
+			quiet: values.quiet === true,
+			skipTests: values["skip-tests"] === true,
+		});
+	} catch (error) {
+		printNukeHelpAndExit(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
+}
+
+void main().catch(printCliErrorAndExit);

--- a/scripts/nuke/run.tsx
+++ b/scripts/nuke/run.tsx
@@ -1,0 +1,83 @@
+import { type ReactNode, useCallback } from "react";
+
+import { colorify } from "../colorify";
+import { runCheck } from "../container/check";
+import { runCleanup } from "../container/cleanup";
+import { setContainerStack } from "../container/stack";
+import { runLocalCleanupSteps } from "../local/cleanup";
+import { runLocalSetupSteps } from "../local/setup";
+import { renderAndExit } from "../render-and-exit";
+import { runStepsInTerminal } from "../run-terminal-steps";
+import { StepProgressApp, type StepProgressStep } from "../step-progress";
+
+export interface NukeOptions {
+	readonly quiet: boolean;
+	readonly skipTests: boolean;
+}
+
+function getNukePrepareSteps(options: NukeOptions): readonly StepProgressStep[] {
+	return [
+		{
+			label: "Cleaning local artifacts",
+			run: () => runLocalCleanupSteps(),
+		},
+		{
+			label: "Stopping dev compose stack",
+			run: async () => {
+				setContainerStack("dev");
+				await runCleanup(["--quiet"]);
+			},
+		},
+		{
+			label: "Stopping prod compose stack",
+			run: async () => {
+				setContainerStack("prod");
+				await runCleanup(["--quiet"]);
+			},
+		},
+		{
+			label: "Bootstrapping local workspace",
+			run: () => runLocalSetupSteps(options.skipTests),
+		},
+	];
+}
+
+function getNukeComposeSteps(): readonly StepProgressStep[] {
+	return [
+		{
+			label: "Validating dev compose stack",
+			run: async () => {
+				setContainerStack("dev");
+				await runCheck(["--quiet"]);
+			},
+		},
+		{
+			label: "Validating prod compose stack",
+			run: async () => {
+				setContainerStack("prod");
+				await runCheck(["--quiet"]);
+			},
+		},
+	];
+}
+
+function NukePrepareApp({ options }: { readonly options: NukeOptions }): ReactNode {
+	const resolveSteps = useCallback(() => getNukePrepareSteps(options), [options]);
+	return (
+		<StepProgressApp completedHeading="Local workspace prepared" resolveSteps={resolveSteps} />
+	);
+}
+
+export async function runNuke(options: NukeOptions): Promise<void> {
+	const prepareSteps = getNukePrepareSteps(options);
+	const composeSteps = getNukeComposeSteps();
+
+	if (options.quiet) {
+		for (const step of [...prepareSteps, ...composeSteps]) await step.run();
+		return;
+	}
+
+	await renderAndExit(<NukePrepareApp options={options} />);
+	await runStepsInTerminal(composeSteps, { heading: "Validating compose stacks" });
+	console.log(colorify.green("✓ Nuke completed — workspace reset and verified\n"));
+}

--- a/scripts/render-and-exit.tsx
+++ b/scripts/render-and-exit.tsx
@@ -1,8 +1,12 @@
 import { type RenderOptions, render } from "ink";
 import type { ReactElement } from "react";
+import { INK_PROGRESS_ENV } from "./compose-plain-progress";
 import { printCliError } from "./format-cli-error";
 
 export async function renderAndExit(tree: ReactElement, inkOptions?: RenderOptions): Promise<void> {
+	const previousInkProgress = process.env[INK_PROGRESS_ENV];
+	process.env[INK_PROGRESS_ENV] = "1";
+
 	const { waitUntilExit, unmount } = render(tree, {
 		stdout: process.stderr,
 		...inkOptions,
@@ -13,6 +17,12 @@ export async function renderAndExit(tree: ReactElement, inkOptions?: RenderOptio
 		unmount();
 		printCliError(error);
 		process.exit(1);
+	} finally {
+		if (previousInkProgress === undefined) {
+			delete process.env[INK_PROGRESS_ENV];
+		} else {
+			process.env[INK_PROGRESS_ENV] = previousInkProgress;
+		}
 	}
 	unmount();
 }

--- a/scripts/run-terminal-steps.ts
+++ b/scripts/run-terminal-steps.ts
@@ -1,0 +1,17 @@
+import { colorify } from "./colorify";
+import type { StepProgressStep } from "./step-progress";
+
+export async function runStepsInTerminal(
+	steps: readonly StepProgressStep[],
+	options?: { readonly heading?: string },
+): Promise<void> {
+	if (options?.heading !== undefined) {
+		console.log(colorify.cyan(`\n${options.heading}\n`));
+	}
+
+	for (const step of steps) {
+		console.log(`${colorify.cyan("→")} ${step.label}`);
+		await step.run();
+		console.log(`${colorify.green("✓")} ${step.label}\n`);
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `bun run nuke` factory-reset flow for local artifacts and both compose stacks, and improves container/local CLIs so Ink progress UIs do not fight Docker Compose’s animated output. App Dockerfiles now use BuildKit cache mounts for faster `bun install` during image builds.

## What has changed?

- **`bun run nuke`** — Wipes local build artifacts, tears down dev and prod compose stacks, re-runs local setup, then smoke-checks both stacks (`scripts/nuke/`). README quick start uses `bun nuke` instead of separate cleanup/setup commands.
- **Compose + Ink** — `scripts/compose-plain-progress.ts` sets `COMPOSE_ANSI=never` / `BUILDKIT_PROGRESS=plain` and injects `compose --progress plain` while Ink is active; container `check`/`setup` use a terminal step runner when not in quiet mode.
- **Quiet mode** — `local setup` / `local cleanup` and container cleanup honor `--quiet` for scriptable runs (used by nuke).
- **Docker** — Pruned install stages use per-app Bun cache mounts; dev compose mounts `intershell.config.ts`.
- **Deps** — `intershell` 0.6.1 → 0.6.2.
- **Storefront** — `next-env.d.ts` routes import path updated for current Next dev output.

## How to test it?

- [ ] `bun overall`
- [ ] `bun run nuke -- --help` — help renders
- [ ] `bun run nuke` — full reset completes (or `bun run nuke -- --quiet --skip-tests` for a faster pass)
- [ ] `bun run container setup` / `bun run container check` — progress output stays readable with Ink
- [ ] `bun run container --prod compose build` — verify Docker builds still succeed with cache mounts


Made with [Cursor](https://cursor.com)